### PR TITLE
Added MANIFEST.in to allow packaging with setup.py to include the template files

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,10 +1,55 @@
-# kind (Kubernetes) Install
+# Setup
 
-This is for testing only. Go to [kind](https://kind.sigs.k8s.io/) for usage.
+! Ubuntu Example. Your distro may vary.
+! These instructions (especially the /etc/hosts and ingress parts) are for running this all on a remote VM and connecting via your local machine (Your setup may vary)
 
-## Create a kind configuration file:
-``` yaml
-# three node (two workers) cluster config
+## Install Docker
+
+```
+sudo apt update
+sudo apt install apt-transport-https ca-certificates curl software-properties-common
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+sudo apt update
+sudo apt install docker-ce docker-ce-cli containerd.io
+
+# Verify docker installation
+sudo systemctl status docker
+```
+
+## Install kind
+
+```
+curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.20.0/kind-linux-amd64
+chmod +x ./kind
+sudo mv ./kind /usr/local/bin/kind
+kind version
+```
+
+## Install kubectl
+
+```
+sudo snap install kubectl --classic
+kubectl version --client
+```
+
+## Install helm
+
+```
+sudo snap install helm --classic
+helm version
+```
+
+
+# Configuration
+
+## Extend the 
+
+## Create a kind configuration file
+
+```
+cat <<EOF > cluster-config.yaml
+# three node (two workers) cluster config with the control-plane running on 8080 so as not to clash with the Kriten service
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
@@ -16,14 +61,15 @@ nodes:
       kubeletExtraArgs:
         node-labels: "ingress-ready=true"
   extraPortMappings:
-  - containerPort: 80
-    hostPort: 80
+  - containerPort: 8080      # Move kind control plane to port 8080
+    hostPort: 8080
     protocol: TCP
   - containerPort: 443
     hostPort: 443
     protocol: TCP
 - role: worker
 - role: worker
+EOF
 ```
 
 ## Start cluster:
@@ -40,7 +86,7 @@ kind-worker          Ready    <none>          22s   v1.31.0
 kind-worker2         Ready    <none>          22s   v1.31.0
 ```
 
-## Helm install NetBox:
+## Helm install NetBox with Kriten and Branching plugins
 
 :green_circle: **Tip:** To use publicly available image:
 ```
@@ -53,18 +99,18 @@ helm install netbox startechnica/netbox \
     --set superuser.password=kubecode
 ```
 
+## Check the NetBox installation
+
+```
+kubectl get pods
+```
+
 ## Helm install Kriten:
 ```
 helm repo add kriten https://kriten-io.github.io/kriten-charts/
 helm install kriten kriten/kriten
 ```
 
-## Edit /etc/hosts:
-```
-# Hostnames must match kubernetes ingress hosts
-192.168.1.62    kriten-local
-192.168.1.62    netbox-local
-```
 ## Install nginx:
 ```
 kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
@@ -101,6 +147,39 @@ spec:
               number: 80
 ```
 
-Connect to http://kriten-local and http://netbox-local
+## Forward port 80 on the VM to your local machine
+
+- I do this using Visual Studio Code's built-in functionality, but you could also use SSH port forwarding directly
+
+```
+ssh -L 8080:localhost:80 your_user@your_vm_public_ip
+```
+
+## Edit /etc/hosts on your **local machine**:
+```
+# Kriten NetBox
+127.0.0.1    kriten-local
+127.0.0.1    netbox-local
+```
+
+## Access NetBox (Alter the port to whichever local port you're forwarding to)
+
+http://netbox-local:57791
+
+## Access Kriten (Alter the port to whichever local port you're forwarding to)
+
+Swagger: http://kriten-local:57791/swagger/index.html
+
+! Note: I haven't figured out how to connect to the Kriten GUI yet. Possibly related to `frontend.enabled` in here: https://kriten.io/#prerequisites-and-guidelines
+
+# Follow the instructions in the README to create the various Kriten elements
+
+https://github.com/mrmrcoleman/kriten-netbox-plugin/blob/main/README.md
+
+# 
+
+
+
+Connect to http://kriten-local and 
 
 For information to use [Kriten](https://kriten.io/user_guide/getting_started/)

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include kriten_netbox/templates *.html


### PR DESCRIPTION
**Steps to reproduce**

- Install `kriten-netbox` via pypi package (`pip install kriten-netbox`) or by building the package locally (`pip install .`) in a NetBox 4.1.1 instance
- Start NetBox
- Create a Cluster or Runner

```
<class 'django.template.exceptions.TemplateDoesNotExist'>

kriten_netbox/kritencluster.html

Python version: 3.12.3
NetBox version: 4.1.1 # This also happens with 4.1.0
Plugins: 
  kriten_netbox: 0.1.1
  netbox_branching: 0.4.0
```

**Root Cause**

The plugin works when installed through the provided `helm` chart in this repo, but when installed manually (without `helm`) in a separate NetBox 4.1.1 instance it fails with exceptions like the above because the templates are missing from the package.

The `kriten-netbox` `pypi` package doesn't include the `templates` and building with `pip install .` also doesn't install them.

**Solution**

Include the proposed `MANIFEST.in` in the repo and then build the package like this:

```
python setup.py sdist bdist_wheel
pip install dist/kriten_netbox-0.1.1-py3-none-any.whl
```

**Notes**

- I haven't include updates to the documentation in this PR because the `helm` approach does work but I think you should document building the package for those who would like to install it elsewhere
- It's unclear why the `helm` approach works, because when I inspect the NetBox pod I can see that the templates are also missing their, but it doesn't lead to an exception. I didn't have time to look into how the `helm` chart was applying the plugins